### PR TITLE
chore: update connect library and peer deps

### DIFF
--- a/.github/workflows/workflow-cicd.yml
+++ b/.github/workflows/workflow-cicd.yml
@@ -6,6 +6,7 @@ on:
       - main
       - beta
   pull_request_target:
+    types: [assigned, opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}

--- a/.github/workflows/workflow-cicd.yml
+++ b/.github/workflows/workflow-cicd.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - beta
-  pull_request:
+  pull_request_target:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}

--- a/packages/nestjs-bufconnect/package.json
+++ b/packages/nestjs-bufconnect/package.json
@@ -22,15 +22,15 @@
     "url": "https://github.com/wisewolf-oss/nestjs-bufconnect.git"
   },
   "dependencies": {
-    "@bufbuild/connect": "^0.8.4",
-    "@bufbuild/connect-node": "^0.8.4",
-    "@bufbuild/protobuf": "^1.2.0"
+    "@connectrpc/connect": "^1.4.0",
+    "@connectrpc/connect-node": "^1.4.0",
+    "@bufbuild/protobuf": "^1.7.2"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.0",
-    "@nestjs/core": "^9.0.0",
-    "@nestjs/platform-express": "^9.0.0",
-    "@nestjs/microservices": "^9.0.0",
+    "@nestjs/common": "^9.0.0 || ^10.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0",
+    "@nestjs/platform-express": "^9.0.0 || ^10.0.0",
+    "@nestjs/microservices": "^9.0.0 || ^10.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0"
   }

--- a/packages/nestjs-bufconnect/src/lib/nestjs-bufconnect.decorator.spec.ts
+++ b/packages/nestjs-bufconnect/src/lib/nestjs-bufconnect.decorator.spec.ts
@@ -1,8 +1,8 @@
 import {
   connectNodeAdapter,
   createGrpcTransport,
-} from '@bufbuild/connect-node';
-import { ConnectRouter, createPromiseClient } from '@bufbuild/connect';
+} from '@connectrpc/connect-node';
+import { ConnectRouter, createPromiseClient } from '@connectrpc/connect';
 import * as http2 from 'http2';
 import { GrpcMethodStreamingType, MessageHandler } from '@nestjs/microservices';
 import { MethodType } from './nestjs-bufconnect.interface';

--- a/packages/nestjs-bufconnect/src/lib/nestjs-bufconnect.interface.ts
+++ b/packages/nestjs-bufconnect/src/lib/nestjs-bufconnect.interface.ts
@@ -3,7 +3,7 @@
  * (HTTP, HTTPS, HTTP2, HTTP2_INSECURE) and their options. It also provides types for handling
  * server instances and other utility types.
  */
-import { ConnectRouterOptions } from '@bufbuild/connect';
+import { ConnectRouterOptions } from '@connectrpc/connect';
 import * as http from 'http';
 import * as https from 'https';
 import * as http2 from 'http2';

--- a/packages/nestjs-bufconnect/src/lib/nestjs-bufconnect.strategy.ts
+++ b/packages/nestjs-bufconnect/src/lib/nestjs-bufconnect.strategy.ts
@@ -1,4 +1,4 @@
-import { ConnectRouter } from '@bufbuild/connect';
+import { ConnectRouter } from '@connectrpc/connect';
 import { isString } from '@nestjs/common/utils/shared.utils';
 import {
   CustomTransportStrategy,
@@ -12,7 +12,7 @@ import { ServerTypeOptions } from './nestjs-bufconnect.interface';
 import { addServicesToRouter, createServiceHandlersMap } from './util';
 
 /**
- * A custom transport strategy for NestJS microservices that integrates with the '@bufbuild/connect-es' package.
+ * A custom transport strategy for NestJS microservices that integrates with the '@connectrpc/connect-es' package.
  *
  * @remarks
  * This class extends the `Server` class provided by NestJS and implements the `CustomTransportStrategy` interface.

--- a/packages/nestjs-bufconnect/src/lib/server/server.spec.ts
+++ b/packages/nestjs-bufconnect/src/lib/server/server.spec.ts
@@ -1,4 +1,4 @@
-import { ConnectRouter } from '@bufbuild/connect';
+import { ConnectRouter } from '@connectrpc/connect';
 import * as selfsigned from 'selfsigned';
 
 import * as https from 'https';

--- a/packages/nestjs-bufconnect/src/lib/server/server.ts
+++ b/packages/nestjs-bufconnect/src/lib/server/server.ts
@@ -1,8 +1,8 @@
 import * as http from 'http';
 import * as https from 'https';
 import * as http2 from 'http2';
-import { ConnectRouter } from '@bufbuild/connect';
-import { connectNodeAdapter } from '@bufbuild/connect-node';
+import { ConnectRouter } from '@connectrpc/connect';
+import { connectNodeAdapter } from '@connectrpc/connect-node';
 import {
   Http2InsecureOptions,
   Http2Options,

--- a/packages/nestjs-bufconnect/src/lib/util/router.util.spec.ts
+++ b/packages/nestjs-bufconnect/src/lib/util/router.util.spec.ts
@@ -1,4 +1,4 @@
-import { ConnectRouter, createConnectRouter } from '@bufbuild/connect';
+import { ConnectRouter, createConnectRouter } from '@connectrpc/connect';
 import { MessageHandler } from '@nestjs/microservices';
 import { MethodType } from '../nestjs-bufconnect.interface';
 import { CustomMetadataStore } from '../nestjs-bufconnect.provider';

--- a/packages/nestjs-bufconnect/src/lib/util/router.util.ts
+++ b/packages/nestjs-bufconnect/src/lib/util/router.util.ts
@@ -1,4 +1,4 @@
-import { ConnectRouter, ServiceImpl } from '@bufbuild/connect';
+import { ConnectRouter, ServiceImpl } from '@connectrpc/connect';
 import { ServiceType } from '@bufbuild/protobuf';
 import { MessageHandler } from '@nestjs/microservices';
 import { lastValueFrom, Observable } from 'rxjs';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
   .:
     dependencies:
@@ -154,26 +158,26 @@ importers:
 
   packages/nestjs-bufconnect:
     dependencies:
-      '@bufbuild/connect':
-        specifier: ^0.8.4
-        version: 0.8.4(@bufbuild/protobuf@1.2.0)
-      '@bufbuild/connect-node':
-        specifier: ^0.8.4
-        version: 0.8.4(@bufbuild/protobuf@1.2.0)
       '@bufbuild/protobuf':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.7.2
+        version: 1.7.2
+      '@connectrpc/connect':
+        specifier: ^1.4.0
+        version: 1.4.0(@bufbuild/protobuf@1.7.2)
+      '@connectrpc/connect-node':
+        specifier: ^1.4.0
+        version: 1.4.0(@bufbuild/protobuf@1.7.2)(@connectrpc/connect@1.4.0)
       '@nestjs/common':
-        specifier: ^9.0.0
+        specifier: ^9.0.0 || ^10.0.0
         version: 9.3.12(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core':
-        specifier: ^9.0.0
+        specifier: ^9.0.0 || ^10.0.0
         version: 9.3.12(@nestjs/common@9.3.12)(@nestjs/microservices@9.3.12)(@nestjs/platform-express@9.3.12)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/microservices':
-        specifier: ^9.0.0
+        specifier: ^9.0.0 || ^10.0.0
         version: 9.3.12(@nestjs/common@9.3.12)(@nestjs/core@9.3.12)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/platform-express':
-        specifier: ^9.0.0
+        specifier: ^9.0.0 || ^10.0.0
         version: 9.3.12(@nestjs/common@9.3.12)(@nestjs/core@9.3.12)
       reflect-metadata:
         specifier: ^0.1.13
@@ -1835,35 +1839,10 @@ packages:
       }
     dev: true
 
-  /@bufbuild/connect-node@0.8.4(@bufbuild/protobuf@1.2.0):
+  /@bufbuild/protobuf@1.7.2:
     resolution:
       {
-        integrity: sha512-i2C5Q/BiVA29Uj9msn7hiFvlzPp0jiU+P+MBfZVf3vg2PmklnAoA9UETt3MNjpOHd54fvJkAK964koc7iVyCKA==,
-      }
-    engines: { node: '>=16.0.0' }
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.0.0
-    dependencies:
-      '@bufbuild/connect': 0.8.4(@bufbuild/protobuf@1.2.0)
-      '@bufbuild/protobuf': 1.2.0
-      headers-polyfill: 3.1.2
-    dev: false
-
-  /@bufbuild/connect@0.8.4(@bufbuild/protobuf@1.2.0):
-    resolution:
-      {
-        integrity: sha512-99FwsvhEDTUJAXLJEyqdKhAle/MuFrRtkRBdRFLH2oNdI5Tv0Qaa7oMcQXKPFPQDfRdJEZe+dt8scmRVN55njA==,
-      }
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.0.0
-    dependencies:
-      '@bufbuild/protobuf': 1.2.0
-    dev: false
-
-  /@bufbuild/protobuf@1.2.0:
-    resolution:
-      {
-        integrity: sha512-MBVuQMOBHxgGnZ9XCUIi8WOy5O/T4ma3TduCRhRvndv3UDbG9cHgd8h6nOYSGyBYPEvXf1z9nTwhp8mVIDbq2g==,
+        integrity: sha512-i5GE2Dk5ekdlK1TR7SugY4LWRrKSfb5T1Qn4unpIMbfxoeGKERKQ59HG3iYewacGD10SR7UzevfPnh6my4tNmQ==,
       }
     dev: false
 
@@ -2129,6 +2108,32 @@ packages:
       chalk: 4.1.2
     dev: true
 
+  /@connectrpc/connect-node@1.4.0(@bufbuild/protobuf@1.7.2)(@connectrpc/connect@1.4.0):
+    resolution:
+      {
+        integrity: sha512-0ANnrr6SvsjevsWEgdzHy7BaHkluZyS6s4xNoVt7RBHFR5V/kT9lPokoIbYUOU9JHzdRgTaS3x5595mwUsu15g==,
+      }
+    engines: { node: '>=16.0.0' }
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.4.2
+      '@connectrpc/connect': 1.4.0
+    dependencies:
+      '@bufbuild/protobuf': 1.7.2
+      '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.7.2)
+      undici: 5.28.3
+    dev: false
+
+  /@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.7.2):
+    resolution:
+      {
+        integrity: sha512-vZeOkKaAjyV4+RH3+rJZIfDFJAfr+7fyYr6sLDKbYX3uuTVszhFe9/YKf5DNqrDb5cKdKVlYkGn6DTDqMitAnA==,
+      }
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.4.2
+    dependencies:
+      '@bufbuild/protobuf': 1.7.2
+    dev: false
+
   /@cspotcode/source-map-support@0.8.1:
     resolution:
       {
@@ -2179,6 +2184,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@fastify/busboy@2.1.1:
+    resolution:
+      {
+        integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==,
+      }
+    engines: { node: '>=14' }
+    dev: false
 
   /@humanwhocodes/config-array@0.9.5:
     resolution:
@@ -9169,13 +9182,6 @@ packages:
     dependencies:
       function-bind: 1.1.1
 
-  /headers-polyfill@3.1.2:
-    resolution:
-      {
-        integrity: sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==,
-      }
-    dev: false
-
   /hook-std@3.0.0:
     resolution:
       {
@@ -11405,8 +11411,6 @@ packages:
       webpack: '*'
     peerDependenciesMeta:
       webpack:
-        optional: true
-      webpack-sources:
         optional: true
     dependencies:
       webpack: 5.76.3
@@ -13724,6 +13728,7 @@ packages:
       {
         integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==,
       }
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -16014,6 +16019,16 @@ packages:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
     dev: true
+
+  /undici@5.28.3:
+    resolution:
+      {
+        integrity: sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==,
+      }
+    engines: { node: '>=14.0' }
+    dependencies:
+      '@fastify/busboy': 2.1.1
+    dev: false
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution:


### PR DESCRIPTION
Was getting some warnings when about peer deps when using Nest 10.x, tested with it and it seems to work.

Also upgraded the connect library which was renamed to `@connectrpc/connect` and updated imports appropriately.